### PR TITLE
XPad driver emulation

### DIFF
--- a/README
+++ b/README
@@ -14,6 +14,19 @@ Currently sixad supports:
 sixad also registers the hardware's MAC/ID in the device name
 (ex: "PLAYSTATION(R)3 Controller (00:XX:X0:0X:XX)".
 
+
+XPad emulation
+ ------------ 
+
+This version contains a modified sixad which permits xpad event emualtion, USB ID emulation, and device name emulation for "XBOX 360 Wireless Receiver", which is the same as is used for wireless 360 controllers in the standard kernel xpad driver.  This makes a lot of games "Just Work".
+
+To enable the xpad emulation option, add the following to the device/default profile configuration:
+  enable_xpad_emulation 1
+
+Note: The emualtion mode disables the acceleromators and giro as well as sbuttons (buttons as axis) automatically so this should be the only configuration option you will need to set.
+
+Note 2: QtSixa has *not* been updated to cover the additonal options.  You will need to manually add the configuration option to emulate the xpad driver to the configuration files.
+
  -------------------------------------
 
 QtSixA and sixad are licensed under the GNU GPL v2 license.

--- a/sixad/shared.cpp
+++ b/sixad/shared.cpp
@@ -77,6 +77,7 @@ struct device_settings init_values(const char *addr)
         settings.joystick.accon = textfile_get_int(pathname, "enable_accon", 0);
         settings.joystick.speed = textfile_get_int(pathname, "enable_speed", 0);
         settings.joystick.pos = textfile_get_int(pathname, "enable_pos", 0);
+        settings.joystick.xpad_emulation = textfile_get_int(pathname, "enable_xpad_emulation", 0);
 
         settings.remote.enabled = textfile_get_int(pathname, "enable_remote", 1);
         settings.remote.numeric = textfile_get_int(pathname, "remote_numberic", 1);
@@ -139,6 +140,7 @@ struct device_settings init_values(const char *addr)
         settings.joystick.accon = textfile_get_int(pathname, "enable_accon", 0);
         settings.joystick.speed = textfile_get_int(pathname, "enable_speed", 0);
         settings.joystick.pos = textfile_get_int(pathname, "enable_pos", 0);
+        settings.joystick.xpad_emulation = textfile_get_int(pathname, "enable_xpad_emulation", 0);
 
         settings.remote.enabled = textfile_get_int(pathname, "enable_remote", 1);
         settings.remote.numeric = textfile_get_int(pathname, "remote_numberic", 1);
@@ -200,6 +202,7 @@ struct device_settings init_values(const char *addr)
         settings.joystick.accon = 0;
         settings.joystick.speed = 0;
         settings.joystick.pos = 0;
+        settings.joystick.xpad_emulation = 0;
 
         settings.remote.enabled = 1;
         settings.remote.numeric = 1;

--- a/sixad/shared.h
+++ b/sixad/shared.h
@@ -36,6 +36,7 @@ struct dev_joystick {
     bool accon;
     bool speed;
     bool pos;
+    bool xpad_emulation;
 };
 
 struct dev_remote {

--- a/sixad/sixaxis.cpp
+++ b/sixad/sixaxis.cpp
@@ -139,47 +139,58 @@ void do_joystick(int fd, unsigned char* buf, struct dev_joystick joystick)
     if (velZ > -30 && velZ < 30) velZ = 0;
 
     if (joystick.buttons) {
-        //part1
-        if (last_jb1 != b1) {
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 0, b1 & 0x01 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 6, b1 & 0x01 ? 1 : 0); //Select button
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 1, b1 & 0x02 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 9, b1 & 0x02 ? 1 : 0);  //Left Stick Click
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 2, b1 & 0x04 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 10, b1 & 0x04 ? 1 : 0);  //Right Stick Click
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 3, b1 & 0x08 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 7, b1 & 0x08 ? 1 : 0);  //Start Button
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 4, b1 & 0x10 ? 1 : 0);  //DPad UP
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 13, b1 & 0x10 ? 1 : 0);  //DPad UP
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 5, b1 & 0x20 ? 1 : 0);  //DPAD Right
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 12, b1 & 0x20 ? 1 : 0);  //DPAD Right
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 6, b1 & 0x40 ? 1 : 0);  //DPad Down
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 14, b1 & 0x40 ? 1 : 0);  //DPad Down
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 7, b1 & 0x80 ? 1 : 0);  //DPad  Left
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 11, b1 & 0x80 ? 1 : 0);  //DPad  Left
-        }
-        //part2
-        if (last_jb2 != b2) {
-/*            uinput_send(fd, EV_KEY, BTN_JOYSTICK +  8, b2 & 0x01 ? 1 : 0); //Left Trigger
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK +  9, b2 & 0x02 ? 1 : 0); //Right Trigger
-*/
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 10, b2 & 0x04 ? 1 : 0); //Left Shoulder
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 4, b2 & 0x04 ? 1 : 0);  //Left Shoulder
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 11, b2 & 0x08 ? 1 : 0); //Right Shoulder
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 5, b2 & 0x08 ? 1 : 0);  //Right Shoulder
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 12, b2 & 0x10 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 3, b2 & 0x10 ? 1 : 0);  //Triangle Button
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 13, b2 & 0x20 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 1, b2 & 0x20 ? 1 : 0);  //Circle Button
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 14, b2 & 0x40 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 0, b2 & 0x40 ? 1 : 0);  //Cross Button
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 15, b2 & 0x80 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 2, b2 & 0x80 ? 1 : 0);  //Square Button
-        }
-        //part3
-        if (last_jb3 != b3) {
-//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 16, b3 & 0x01 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 8, b3 & 0x01 ? 1 : 0);  //PS Button
+        if(joystick.xpad_emulation) {
+            //part1
+            if (last_jb1 != b1) {
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 6, b1 & 0x01 ? 1 : 0); //Select button ->xpad Back Button
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 9, b1 & 0x02 ? 1 : 0);  //Left Stick Click
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 10, b1 & 0x04 ? 1 : 0);  //Right Stick Click
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 7, b1 & 0x08 ? 1 : 0);  //Start Button
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 13, b1 & 0x10 ? 1 : 0);  //DPad UP
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 12, b1 & 0x20 ? 1 : 0);  //DPAD Right
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 14, b1 & 0x40 ? 1 : 0);  //DPad Down
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 11, b1 & 0x80 ? 1 : 0);  //DPad  Left
+            }
+            //part2
+            if (last_jb2 != b2) {
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 4, b2 & 0x04 ? 1 : 0);  //Left Shoulder
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 5, b2 & 0x08 ? 1 : 0);  //Right Shoulder
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 3, b2 & 0x10 ? 1 : 0);  //Triangle Button -> xpad Y Button
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 1, b2 & 0x20 ? 1 : 0);  //Circle Button -> xpad B Button
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 0, b2 & 0x40 ? 1 : 0);  //Cross Button -> xpad A Button
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 2, b2 & 0x80 ? 1 : 0);  //Square Button -> xpad X Button
+            }
+            //part3
+            if (last_jb3 != b3) {
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 8, b3 & 0x01 ? 1 : 0);  //PS Button -> xpad Guide Button
+            }
+        } else {
+            //part1
+            if (last_jb1 != b1) {
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 0, b1 & 0x01 ? 1 : 0);  //Select button
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 1, b1 & 0x02 ? 1 : 0);  //Left Stick Click
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 2, b1 & 0x04 ? 1 : 0);  //Right Stick Click
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 3, b1 & 0x08 ? 1 : 0);  //Start Button
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 4, b1 & 0x10 ? 1 : 0);  //DPad UP
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 5, b1 & 0x20 ? 1 : 0);  //DPAD Right
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 6, b1 & 0x40 ? 1 : 0);  //DPad Down
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 7, b1 & 0x80 ? 1 : 0);  //DPad  Left
+            }
+            //part2
+            if (last_jb2 != b2) {
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK +  8, b2 & 0x01 ? 1 : 0);  //Left Trigger
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK +  9, b2 & 0x02 ? 1 : 0);  //Right Trigger
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 10, b2 & 0x04 ? 1 : 0);  //Left Shoulder
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 11, b2 & 0x08 ? 1 : 0);  //Right Shoulder
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 12, b2 & 0x10 ? 1 : 0);  //Triangle Button
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 13, b2 & 0x20 ? 1 : 0);  //Circle Button
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 14, b2 & 0x40 ? 1 : 0);  //Cross Button
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 15, b2 & 0x80 ? 1 : 0);  //Square Button
+            }
+            //part3
+            if (last_jb3 != b3) {
+                uinput_send(fd, EV_KEY, BTN_JOYSTICK + 16, b3 & 0x01 ? 1 : 0);  //PS Button
+            }
         }
 
         if (b1 > 0 || b2 > 0 || b3 > 0) {
@@ -190,11 +201,14 @@ void do_joystick(int fd, unsigned char* buf, struct dev_joystick joystick)
     //axis
     if (joystick.axis) {
         uinput_send(fd, EV_ABS, 0, lx);
-        uinput_send(fd, EV_ABS, 1, ly);
-//        uinput_send(fd, EV_ABS, 2, rx);
-        uinput_send(fd, EV_ABS, 4, rx);
-//        uinput_send(fd, EV_ABS, 3, ry);
-        uinput_send(fd, EV_ABS, 5, ry);
+        uinput_send(fd, EV_ABS, 1, ly);            
+        if (joystick.xpad_emulation) {
+            uinput_send(fd, EV_ABS, 4, rx);
+            uinput_send(fd, EV_ABS, 5, ry);
+        } else {
+            uinput_send(fd, EV_ABS, 2, rx);
+            uinput_send(fd, EV_ABS, 3, ry);
+        }
 
         if (lx != 0 || ly != 0 || rx != 0 || ry != 0) {
           set_active(true);
@@ -202,7 +216,7 @@ void do_joystick(int fd, unsigned char* buf, struct dev_joystick joystick)
     }
 
     //accelerometer RAW
-    if (joystick.accel) {
+    if (joystick.accel && !joystick.xpad_emulation) {
         uinput_send(fd, EV_ABS, 4, acx);
         uinput_send(fd, EV_ABS, 5, acy);
         uinput_send(fd, EV_ABS, 6, acz);
@@ -210,15 +224,13 @@ void do_joystick(int fd, unsigned char* buf, struct dev_joystick joystick)
     }
 
     //buttons (sensible, as axis)
-    if (joystick.sbuttons) {
+    if (joystick.sbuttons && !joystick.xpad_emulation) {
         uinput_send(fd, EV_ABS, 8, up);
         uinput_send(fd, EV_ABS, 9, right);
         uinput_send(fd, EV_ABS, 10, down);
         uinput_send(fd, EV_ABS, 11, left);
-//        uinput_send(fd, EV_ABS, 12, l2);
-        uinput_send(fd, EV_ABS, 3, l2);
-//        uinput_send(fd, EV_ABS, 13, r2);
-        uinput_send(fd, EV_ABS, 6, r2);
+        uinput_send(fd, EV_ABS, 12, l2);
+        uinput_send(fd, EV_ABS, 13, r2);
         uinput_send(fd, EV_ABS, 14, l1);
         uinput_send(fd, EV_ABS, 15, r1);
 
@@ -230,24 +242,31 @@ void do_joystick(int fd, unsigned char* buf, struct dev_joystick joystick)
         if (up > 0 || right > 0 || down > 0 || left > 0 || l2 > 0 || r2 > 0 || l1 > 0 || r1 > 0 || tri > 0 || cir > 0 || cro > 0 || squ > 0 ) {
           set_active(true);
         }
+    } else if (joystick.xpad_emulation) {
+        uinput_send(fd, EV_ABS, 3, l2);
+        uinput_send(fd, EV_ABS, 6, r2);
+
+        if (l2 > 0 || r2 > 0) {
+            set_active(true);
+        }
     }
 
     //acceleration
-    if (joystick.accon) {
+    if (joystick.accon  && !joystick.xpad_emulation) {
         uinput_send(fd, EV_ABS, 20+AXIS_PADDING, accX);
         uinput_send(fd, EV_ABS, 21+AXIS_PADDING, accY);
         uinput_send(fd, EV_ABS, 22+AXIS_PADDING, accZ);
     }
 
     //speed
-    if (joystick.speed) {
+    if (joystick.speed && !joystick.xpad_emulation) {
         uinput_send(fd, EV_ABS, 23+AXIS_PADDING, velX);
         uinput_send(fd, EV_ABS, 24+AXIS_PADDING, velY);
         uinput_send(fd, EV_ABS, 25+AXIS_PADDING, velZ);
     }
 
     //position
-    if (joystick.pos) {
+    if (joystick.pos && !joystick.xpad_emulation) {
         uinput_send(fd, EV_ABS, 26+AXIS_PADDING, posX);
         uinput_send(fd, EV_ABS, 27+AXIS_PADDING, posY);
         uinput_send(fd, EV_ABS, 28+AXIS_PADDING, posZ);

--- a/sixad/sixaxis.cpp
+++ b/sixad/sixaxis.cpp
@@ -141,29 +141,45 @@ void do_joystick(int fd, unsigned char* buf, struct dev_joystick joystick)
     if (joystick.buttons) {
         //part1
         if (last_jb1 != b1) {
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 0, b1 & 0x01 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 1, b1 & 0x02 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 2, b1 & 0x04 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 3, b1 & 0x08 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 4, b1 & 0x10 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 5, b1 & 0x20 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 6, b1 & 0x40 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 7, b1 & 0x80 ? 1 : 0);
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 0, b1 & 0x01 ? 1 : 0);
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 6, b1 & 0x01 ? 1 : 0); //Select button
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 1, b1 & 0x02 ? 1 : 0);
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 9, b1 & 0x02 ? 1 : 0);  //Left Stick Click
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 2, b1 & 0x04 ? 1 : 0);
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 10, b1 & 0x04 ? 1 : 0);  //Right Stick Click
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 3, b1 & 0x08 ? 1 : 0);
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 7, b1 & 0x08 ? 1 : 0);  //Start Button
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 4, b1 & 0x10 ? 1 : 0);  //DPad UP
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 13, b1 & 0x10 ? 1 : 0);  //DPad UP
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 5, b1 & 0x20 ? 1 : 0);  //DPAD Right
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 12, b1 & 0x20 ? 1 : 0);  //DPAD Right
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 6, b1 & 0x40 ? 1 : 0);  //DPad Down
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 14, b1 & 0x40 ? 1 : 0);  //DPad Down
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 7, b1 & 0x80 ? 1 : 0);  //DPad  Left
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 11, b1 & 0x80 ? 1 : 0);  //DPad  Left
         }
         //part2
         if (last_jb2 != b2) {
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK +  8, b2 & 0x01 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK +  9, b2 & 0x02 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 10, b2 & 0x04 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 11, b2 & 0x08 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 12, b2 & 0x10 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 13, b2 & 0x20 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 14, b2 & 0x40 ? 1 : 0);
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 15, b2 & 0x80 ? 1 : 0);
+/*            uinput_send(fd, EV_KEY, BTN_JOYSTICK +  8, b2 & 0x01 ? 1 : 0); //Left Trigger
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK +  9, b2 & 0x02 ? 1 : 0); //Right Trigger
+*/
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 10, b2 & 0x04 ? 1 : 0); //Left Shoulder
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 4, b2 & 0x04 ? 1 : 0);  //Left Shoulder
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 11, b2 & 0x08 ? 1 : 0); //Right Shoulder
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 5, b2 & 0x08 ? 1 : 0);  //Right Shoulder
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 12, b2 & 0x10 ? 1 : 0);
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 3, b2 & 0x10 ? 1 : 0);  //Triangle Button
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 13, b2 & 0x20 ? 1 : 0);
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 1, b2 & 0x20 ? 1 : 0);  //Circle Button
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 14, b2 & 0x40 ? 1 : 0);
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 0, b2 & 0x40 ? 1 : 0);  //Cross Button
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 15, b2 & 0x80 ? 1 : 0);
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 2, b2 & 0x80 ? 1 : 0);  //Square Button
         }
         //part3
         if (last_jb3 != b3) {
-            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 16, b3 & 0x01 ? 1 : 0);
+//            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 16, b3 & 0x01 ? 1 : 0);
+            uinput_send(fd, EV_KEY, BTN_JOYSTICK + 8, b3 & 0x01 ? 1 : 0);  //PS Button
         }
 
         if (b1 > 0 || b2 > 0 || b3 > 0) {
@@ -175,8 +191,10 @@ void do_joystick(int fd, unsigned char* buf, struct dev_joystick joystick)
     if (joystick.axis) {
         uinput_send(fd, EV_ABS, 0, lx);
         uinput_send(fd, EV_ABS, 1, ly);
-        uinput_send(fd, EV_ABS, 2, rx);
-        uinput_send(fd, EV_ABS, 3, ry);
+//        uinput_send(fd, EV_ABS, 2, rx);
+        uinput_send(fd, EV_ABS, 4, rx);
+//        uinput_send(fd, EV_ABS, 3, ry);
+        uinput_send(fd, EV_ABS, 5, ry);
 
         if (lx != 0 || ly != 0 || rx != 0 || ry != 0) {
           set_active(true);
@@ -197,10 +215,13 @@ void do_joystick(int fd, unsigned char* buf, struct dev_joystick joystick)
         uinput_send(fd, EV_ABS, 9, right);
         uinput_send(fd, EV_ABS, 10, down);
         uinput_send(fd, EV_ABS, 11, left);
-        uinput_send(fd, EV_ABS, 12, l2);
-        uinput_send(fd, EV_ABS, 13, r2);
+//        uinput_send(fd, EV_ABS, 12, l2);
+        uinput_send(fd, EV_ABS, 3, l2);
+//        uinput_send(fd, EV_ABS, 13, r2);
+        uinput_send(fd, EV_ABS, 6, r2);
         uinput_send(fd, EV_ABS, 14, l1);
         uinput_send(fd, EV_ABS, 15, r1);
+
         uinput_send(fd, EV_ABS, 16+AXIS_PADDING, tri);
         uinput_send(fd, EV_ABS, 17+AXIS_PADDING, cir);
         uinput_send(fd, EV_ABS, 18+AXIS_PADDING, cro);

--- a/sixad/uinput.cpp
+++ b/sixad/uinput.cpp
@@ -65,14 +65,23 @@ struct uinput_fd *uinput_open(int DEV_TYPE, const char *mac, struct device_setti
     memset(&dev_mk, 0, sizeof(dev_mk));
 
     if (DEV_TYPE == DEV_TYPE_SIXAXIS) {
-        strcpy(dev_name, "PLAYSTATION(R)3 Controller (");
-        strcat(dev_name, mac);
-        strcat(dev_name, ")");
-        snprintf(dev.name, sizeof(dev.name), "%s", dev_name);
-        dev.id.vendor = 0x054c;
-        dev.id.product = 0x0268;
-        dev.id.version = 0x0100;
-        dev.id.bustype = BUS_VIRTUAL;
+        if (settings.joystick.xpad_emulation) {
+            strcpy(dev_name, "Xbox 360 Wireless Receiver");
+            snprintf(dev.name, sizeof(dev.name), "%s", dev_name);
+            dev.id.vendor = 0x045e;
+            dev.id.product = 0x719;
+            dev.id.version = 0x100;
+            dev.id.bustype = BUS_VIRTUAL;
+        } else {
+            strcpy(dev_name, "PLAYSTATION(R)3 Controller (");
+            strcat(dev_name, mac);
+            strcat(dev_name, ")");
+            snprintf(dev.name, sizeof(dev.name), "%s", dev_name);
+            dev.id.vendor = 0x054c;
+            dev.id.product = 0x0268;
+            dev.id.version = 0x0100;
+            dev.id.bustype = BUS_VIRTUAL;
+        }
     } else if (DEV_TYPE == DEV_TYPE_REMOTE) {
         strcpy(dev_name, "PLAYSTATION(R)3 Remote (");
         strcat(dev_name, mac);
@@ -114,51 +123,65 @@ struct uinput_fd *uinput_open(int DEV_TYPE, const char *mac, struct device_setti
 
         // enable all axis and accelerometers
         int pos;
-        for (i=0; i<29; i++) {
-            pos = (i >= 16) ? i+AXIS_PADDING : i;
-/*            if (i >= 0 && i <= 3) {// left & right axis
-                dev.absmax[pos] = 127;
-                dev.absmin[pos] = -127;
-            } else if (i == 4) {  // Accelerometer X (reversed)
-                dev.absmax[pos] = -402;
-                dev.absmin[pos] = -622;
-            } else if (i == 5) {  // Accelerometer Y
-                dev.absmax[pos] = 622;
-                dev.absmin[pos] = 402;
-*/
-            if (i == 0 || i == 1 || i == 4 || i == 5) {  // Left/Right Stick Axis
-                dev.absmax[pos] = 127;
-                dev.absmin[pos] = -128;
-/*            } else if (i == 6) {  // Accelerometer Z
-                dev.absmax[pos] = 622;
-                dev.absmin[pos] = 402;
-*/
-            } else if (i == 3 || i == 6) {  // L2/R2 Axis
-                dev.absmax[pos] = 255;
-                dev.absmin[pos] = 0;
-            } else if (i == 7) {  // Gyro - Does NOT work
-                dev.absmax[pos] = 127;
-                dev.absmin[pos] = -127;
-            } else if (i >= 8 && i <= 19) {  // Buttons
-                dev.absmax[pos] = 255;
-                dev.absmin[pos] = -255;
-            } else if (i >= 20 && i <= 22) { // Acceleration
-                dev.absmax[pos] = 1250;
-                dev.absmin[pos] = -1250;
-            } else if (i >= 23 && i <= 25) { // Speed
-                dev.absmax[pos] = 1250;
-                dev.absmin[pos] = -1250;
-            } else if (i >= 26 && i <= 28) { // Position
-                dev.absmax[pos] = 1250;
-                dev.absmin[pos] = -1250;
-            } else {
-                dev.absmax[pos] = 32767;
-                dev.absmin[pos] = -32767;
-            }
 
-            if (ioctl(ufd->js, UI_SET_ABSBIT, pos) < 0) {
-                syslog(LOG_ERR, "uinput_open()::ioctl(ABS_AXIS) - failed to register axis %i", pos);
-                goto error;
+        if (settings.joystick.xpad_emulation) {
+            for (i=0; i<29; i++) {
+                pos = (i >= 16) ? i+AXIS_PADDING : i;
+                if (i == 0 || i == 1 || i == 4 || i == 5) {  // Left/Right Stick Axis
+                    dev.absmax[pos] = 127;
+                    dev.absmin[pos] = -128;
+                } else if (i == 3 || i == 6) {  // L2/R2 Axis
+                    dev.absmax[pos] = 255;
+                    dev.absmin[pos] = 0;
+                } else {
+                    dev.absmax[pos] = 32767;
+                    dev.absmin[pos] = -32767;
+                }
+
+                if (ioctl(ufd->js, UI_SET_ABSBIT, pos) < 0) {
+                    syslog(LOG_ERR, "uinput_open()::ioctl(ABS_AXIS) - failed to register axis %i", pos);
+                    goto error;
+                }
+            }
+        } else {
+            for (i=0; i<29; i++) {
+                pos = (i >= 16) ? i+AXIS_PADDING : i;
+                if (i >= 0 && i <= 3) {// left & right axis
+                    dev.absmax[pos] = 127;
+                    dev.absmin[pos] = -127;
+                } else if (i == 4) {  // Accelerometer X (reversed)
+                    dev.absmax[pos] = -402;
+                    dev.absmin[pos] = -622;
+                } else if (i == 5) {  // Accelerometer Y
+                    dev.absmax[pos] = 622;
+                    dev.absmin[pos] = 402;
+                } else if (i == 6) {  // Accelerometer Z
+                    dev.absmax[pos] = 622;
+                    dev.absmin[pos] = 402;
+                } else if (i == 7) {  // Gyro - Does NOT work
+                    dev.absmax[pos] = 127;
+                    dev.absmin[pos] = -127;
+                } else if (i >= 8 && i <= 19) {  // Buttons
+                    dev.absmax[pos] = 255;
+                    dev.absmin[pos] = -255;
+                } else if (i >= 20 && i <= 22) { // Acceleration
+                    dev.absmax[pos] = 1250;
+                    dev.absmin[pos] = -1250;
+                } else if (i >= 23 && i <= 25) { // Speed
+                    dev.absmax[pos] = 1250;
+                    dev.absmin[pos] = -1250;
+                } else if (i >= 26 && i <= 28) { // Position
+                    dev.absmax[pos] = 1250;
+                    dev.absmin[pos] = -1250;
+                } else {
+                    dev.absmax[pos] = 32767;
+                    dev.absmin[pos] = -32767;
+                }
+
+                if (ioctl(ufd->js, UI_SET_ABSBIT, pos) < 0) {
+                    syslog(LOG_ERR, "uinput_open()::ioctl(ABS_AXIS) - failed to register axis %i", pos);
+                    goto error;
+                }
             }
         }
 

--- a/sixad/uinput.cpp
+++ b/sixad/uinput.cpp
@@ -116,7 +116,7 @@ struct uinput_fd *uinput_open(int DEV_TYPE, const char *mac, struct device_setti
         int pos;
         for (i=0; i<29; i++) {
             pos = (i >= 16) ? i+AXIS_PADDING : i;
-            if (i >= 0 && i <= 3) {// left & right axis
+/*            if (i >= 0 && i <= 3) {// left & right axis
                 dev.absmax[pos] = 127;
                 dev.absmin[pos] = -127;
             } else if (i == 4) {  // Accelerometer X (reversed)
@@ -125,9 +125,17 @@ struct uinput_fd *uinput_open(int DEV_TYPE, const char *mac, struct device_setti
             } else if (i == 5) {  // Accelerometer Y
                 dev.absmax[pos] = 622;
                 dev.absmin[pos] = 402;
-            } else if (i == 6) {  // Accelerometer Z
+*/
+            if (i == 0 || i == 1 || i == 4 || i == 5) {  // Left/Right Stick Axis
+                dev.absmax[pos] = 127;
+                dev.absmin[pos] = -128;
+/*            } else if (i == 6) {  // Accelerometer Z
                 dev.absmax[pos] = 622;
                 dev.absmin[pos] = 402;
+*/
+            } else if (i == 3 || i == 6) {  // L2/R2 Axis
+                dev.absmax[pos] = 255;
+                dev.absmin[pos] = 0;
             } else if (i == 7) {  // Gyro - Does NOT work
                 dev.absmax[pos] = 127;
                 dev.absmin[pos] = -127;


### PR DESCRIPTION
As good as it would be for most Linux games to support all drivers, we seem to be in a situation where the default support is for Xbox 360 controllers only.

I have implemented an emulation of the Linux Kernel xpad driver events and a configuration option to enable this mode.  Sbuttons (with the exception of the triggers) are disabled as well as the accelerometers/gyro when this mode is enabled.
